### PR TITLE
adding version label to webhook

### DIFF
--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/_resource.tpl
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/_resource.tpl
@@ -14,3 +14,7 @@ room for such suffix.
 {{- define "resource.default.namespace" -}}
 giantswarm
 {{- end -}}
+
+{{- define "resource.app.version" -}}
+0.0.0
+{{- end -}}

--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/deploy.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/deploy.yaml
@@ -46,7 +46,7 @@ spec:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }}
-        - --watch-filter=0.0.0
+        - --watch-filter={{ include "resource.app.version" . }}
         command:
         - /manager
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/webhook/webhook.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/webhook/webhook.yaml
@@ -16,6 +16,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.kubeadmconfig.bootstrap.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - bootstrap.cluster.x-k8s.io


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16003
We want the webhook to only watch resources that are reconciled by its respective controller, so we version it.