### PR TITLE
removed kube-rbac-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ 
+### Removed
+
+- Remove kube-rbac-proxy for the metrics endpoint.
 
 ## [0.3.14-gs2] - 2021-05-27
 

--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/deploy.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/deploy.yaml
@@ -28,22 +28,7 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: {{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.rbacproxy.image.name }}:{{ .Values.rbacproxy.image.tag }}
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      - args:
-        - --metrics-addr=127.0.0.1:8080
+        - --metrics-addr=0.0.0.0:8080
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }}
         - --watch-filter={{ .Values.watchfilter }}
         command:
@@ -54,6 +39,10 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/rbac.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/rbac.yaml
@@ -90,26 +90,6 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    {{- include "labels.common" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}-proxy
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -135,21 +115,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "resource.default.name" . }}-manager
-subjects:
-- kind: ServiceAccount
-  name: {{ include "resource.default.name" . }}
-  namespace: {{ include "resource.default.namespace" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    {{- include "labels.common" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "resource.default.name" . }}-proxy
 subjects:
 - kind: ServiceAccount
   name: {{ include "resource.default.name" . }}

--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/service.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/service.yaml
@@ -7,15 +7,14 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
   annotations:
     giantswarm.io/monitoring: "true"
-    prometheus.io/scheme: "https"
   name: {{ include "resource.default.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: http
+    port: 8080
     protocol: TCP
-    targetPort: https
+    targetPort: http
   selector:
     control-plane: controller-manager
     {{- include "labels.selector" . | nindent 4 }}

--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/webhook/deployment.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/webhook/deployment.yaml
@@ -20,17 +20,7 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.rbacproxy.image.name }}:{{ .Values.rbacproxy.image.tag }}"
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-      - args:
-        - --metrics-addr=127.0.0.1:8080
+        - --metrics-addr=0.0.0.0:8080
         - --webhook-port=9443
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }}
         command:

--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/webhook/service.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/webhook/service.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ include "resource.default.namespace" . }}
   annotations:
     giantswarm.io/monitoring: "true"
+    giantswarm.io/monitoring-port: "8080"
 spec:
   ports:
   - port: 443

--- a/helm/cluster-api-bootstrap-provider-kubeadm/templates/webhook/service.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/templates/webhook/service.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: {{ include "resource.default.namespace" . }}
   annotations:
     giantswarm.io/monitoring: "true"
-    prometheus.io/scheme: "https"
 spec:
   ports:
   - port: 443

--- a/helm/cluster-api-bootstrap-provider-kubeadm/values.yaml
+++ b/helm/cluster-api-bootstrap-provider-kubeadm/values.yaml
@@ -5,10 +5,6 @@ project:
 image:
   name: giantswarm/kubeadm-bootstrap-controller
   tag: bb90d2037f840c82ee2fd61a181699b94bbbb53e
-rbacproxy:
-  image:
-    name: giantswarm/kube-rbac-proxy
-    tag: v0.4.1
 
 featuregates:
   machinepool: true


### PR DESCRIPTION
According to upstream direction (https://github.com/kubernetes-sigs/cluster-api/issues/4679) this PR removes the rbac proxy from the metrics endpoint.
We don't use it anywhere else and it's just better to not have it for conformity